### PR TITLE
Speed up included hook, remove global list of receivers

### DIFF
--- a/bench/script.rb
+++ b/bench/script.rb
@@ -1,0 +1,27 @@
+require 'much-plugin'
+require 'benchmark'
+
+module Methods; end
+
+module MyMixin
+  def self.included(receiver)
+    receiver.class_eval{ include Methods }
+  end
+end
+
+module MyPlugin
+  include MuchPlugin
+
+  plugin_included do
+    include Methods
+  end
+end
+
+Benchmark.bmbm do |x|
+  x.report("MyMixin") do
+    10_000.times{ Class.new{ include MyMixin } }
+  end
+  x.report("MyPlugin") do
+    10_000.times{ Class.new{ include MyPlugin } }
+  end
+end

--- a/lib/much-plugin.rb
+++ b/lib/much-plugin.rb
@@ -3,28 +3,34 @@ require "much-plugin/version"
 module MuchPlugin
 
   def self.included(receiver)
-    receiver.class_eval do
-      extend ClassMethods
-
-      # install an included hook that first checks if this plugin has
-      # already been installed on the reciever.  If it has not been,
-      # class eval each callback on the receiver.
-
-      def self.included(plugin_receiver)
-        return if self.much_plugin_receivers.include?(plugin_receiver)
-
-        self.much_plugin_receivers.push(plugin_receiver)
-        self.much_plugin_included_hooks.each do |hook|
-          plugin_receiver.class_eval(&hook)
-        end
-      end
-
-    end
+    receiver.class_eval{ extend ClassMethods }
   end
 
   module ClassMethods
 
-    def much_plugin_receivers;      @much_plugin_receivers      ||= []; end
+    # install an included hook that first checks if this plugin's receiver mixin
+    # has already been included.  If it has not been, include the receiver mixin
+    # and run all of the `plugin_included` hooks
+    def included(plugin_receiver)
+      return if plugin_receiver.include?(self.much_plugin_included_detector)
+      plugin_receiver.send(:include, self.much_plugin_included_detector)
+
+      self.much_plugin_included_hooks.each do |hook|
+        plugin_receiver.class_eval(&hook)
+      end
+    end
+
+    # the included detector is an empty module that is only used to detect if
+    # the plugin has been included or not, it doesn't add any behavior or
+    # methods to the object receiving the plugin; we use `const_set` to name the
+    # module so if its seen in the ancestors it doesn't look like some random
+    # module and it can be tracked back to much-plugin
+    def much_plugin_included_detector
+      @much_plugin_included_detector ||= Module.new.tap do |m|
+        self.const_set("MuchPluginIncludedDetector", m)
+      end
+    end
+
     def much_plugin_included_hooks; @much_plugin_included_hooks ||= []; end
 
     def plugin_included(&hook)

--- a/test/unit/much-plugin_tests.rb
+++ b/test/unit/much-plugin_tests.rb
@@ -13,15 +13,19 @@ module MuchPlugin
     end
     subject{ @plugin }
 
-    should have_imeths :much_plugin_included_hooks, :much_plugin_receivers
+    should have_imeths :much_plugin_included_detector, :much_plugin_included_hooks
     should have_imeths :plugin_included
+
+    should "know its included detector" do
+      mixin = subject.much_plugin_included_detector
+      assert_instance_of Module, mixin
+      assert_same mixin, subject.much_plugin_included_detector
+      exp = subject::MuchPluginIncludedDetector
+      assert_same exp, subject.much_plugin_included_detector
+    end
 
     should "have no plugin included hooks by default" do
       assert_empty subject.much_plugin_included_hooks
-    end
-
-    should "have no plugin receivers by default" do
-      assert_empty subject.much_plugin_receivers
     end
 
     should "append hooks" do


### PR DESCRIPTION
This speeds up a plugin's included hook by changing the how it
detects if its been included or not. As part of this, the list of
receivers that each plugin stored has been removed as it is no
longer needed. Overall this doesn't change the core functionality
of much-plugin.

This changes how a plugin detects if its been included or not.
Previously, it would see if its been added to a list of receivers
that it stored and if not, it would add itself and run its hooks.
Now, it uses an included detector mixin that is unique to the
plugin. Since the plugin controls when this mixin is included, the
plugin can check in its included hook if its detector mixin has
been included. If not, include it and class eval its plugin hooks,
otherwise do nothing.

This makes plugin inclusion much faster and avoids a global list
of receivers that can build up. Typically, the list of receivers
should only be a handful of objects but if much-plugin is used with
an algorithm that creates anonymous classes then the list of
receivers can grow to a very large array. Furthermore, the array
keeps the classes from being garbage collected because it is always
holding a reference to them.

This also adds a bench script for comparing much-plugin's
performance with a regular mixin. Using much-plugin should always
be slightly slower but it should be a fairly insignificant
amount (about 1/10th of a millisecond on 10,000 iterations).

@kellyredding - Ready for review. This does technically include backwards incompatible changes in that you can know longer ask a plugin what all it has been included on (the `much_plugin_receivers` method).

Here's the benchmark results I got:

**MuchPlugin master**

```
Rehearsal --------------------------------------------
MyMixin    0.090000   0.000000   0.090000 (  0.089614)
MyPlugin   6.130000   0.010000   6.140000 (  6.145740)
----------------------------------- total: 6.230000sec

               user     system      total        real
MyMixin    0.090000   0.010000   0.100000 (  0.095209)
MyPlugin  23.910000   0.030000  23.940000 ( 23.948648)
```

**MuchPlugin jcr-use-receiver-mixin** (this branch)

```
Rehearsal --------------------------------------------
MyMixin    0.090000   0.000000   0.090000 (  0.091893)
MyPlugin   0.150000   0.010000   0.160000 (  0.153101)
----------------------------------- total: 0.250000sec

               user     system      total        real
MyMixin    0.090000   0.000000   0.090000 (  0.088852)
MyPlugin   0.140000   0.000000   0.140000 (  0.145152)
```
