### PR TITLE
add convenience methods for defining methods on plugin receivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,69 @@ Mix `MuchPlugin` in on other mixins that act as "plugins" to other components.  
 
 This allows you to define multiple hooks separately and ensures each hook will only be executed once - even if your plugin is mixed in multiple times on the same receiver.
 
+### `plugin_class_methods` / `plugin_instance_methods`
+
+MuchPlugin provides convenience methods for defining instance/class methods on plugin receivers:
+
+```ruby
+requre "much-plugin"
+
+module MyPluginMixin
+  include MuchPlugin
+
+  plugin_class_methods do
+    # define some methods ...
+    # - these methods will become class methods on the receiver
+  end
+
+  plugin_instance_methods do
+    # define some methods ...
+    # - these methods will become instance methods on the receiver
+  end
+end
+```
+
+## Example
+
+```ruby
+requre "much-plugin"
+
+module AnotherMixin
+  def another
+    "another"
+  end
+end
+
+module MyPlugin
+  include MuchPlugin
+
+  plugin_included do
+    include AnotherMixin
+  end
+
+  plugin_class_methods do
+    def a_class_method
+      "a-class-method"
+    end
+  end
+
+  plugin_instance_methods do
+    def an_instance_method
+      "an-instance-method"
+    end
+  end
+end
+
+class MyClass
+  include MyPlugin
+end
+
+my_class = MyClass.new
+my_class.another            # => "another"
+my_class.an_instance_method # => "an-instance-method"
+MyClass.a_class_method      # => "a-class-method"
+```
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/README.md
+++ b/README.md
@@ -5,20 +5,17 @@ An API to ensure mixin included logic (the "plugin") only runs once.
 ## Usage
 
 ```ruby
-requre 'much-plugin'
+requre "much-plugin"
 
 module MyPluginMixin
   include MuchPlugin
 
   plugin_included do
-
-    # ... do some stuff ...
+    # do some stuff ...
     # - will be class eval'd in the scope of the receiver of `MyPluginMixin`
     # - will only be executed once per receiver, no matter how many times
     #   `MyPluginMixin` is included in that receiver
-
   end
-
 end
 ```
 

--- a/lib/much-plugin.rb
+++ b/lib/much-plugin.rb
@@ -16,6 +16,16 @@ module MuchPlugin
       self.much_plugin_included_blocks.each do |block|
         plugin_receiver.class_eval(&block)
       end
+
+      self.much_plugin_class_method_blocks.each do |block|
+        self.much_plugin_class_methods_module.class_eval(&block)
+      end
+      plugin_receiver.send(:extend, self.much_plugin_class_methods_module)
+
+      self.much_plugin_instance_method_blocks.each do |block|
+        self.much_plugin_instance_methods_module.class_eval(&block)
+      end
+      plugin_receiver.send(:include, self.much_plugin_instance_methods_module)
     end
 
     # the included detector is an empty module that is only used to detect if
@@ -29,12 +39,40 @@ module MuchPlugin
       end
     end
 
+    def much_plugin_class_methods_module
+      @much_plugin_class_methods_module ||= Module.new.tap do |m|
+        self.const_set("MuchPluginClassMethods", m)
+      end
+    end
+
+    def much_plugin_instance_methods_module
+      @much_plugin_instance_methods_module ||= Module.new.tap do |m|
+        self.const_set("MuchPluginInstanceMethods", m)
+      end
+    end
+
     def much_plugin_included_blocks
       @much_plugin_included_blocks ||= []
     end
 
+    def much_plugin_class_method_blocks
+      @much_plugin_class_method_blocks ||= []
+    end
+
+    def much_plugin_instance_method_blocks
+      @much_plugin_instance_method_blocks ||= []
+    end
+
     def plugin_included(&block)
       self.much_plugin_included_blocks << block
+    end
+
+    def plugin_class_methods(&block)
+      self.much_plugin_class_method_blocks << block
+    end
+
+    def plugin_instance_methods(&block)
+      self.much_plugin_instance_method_blocks << block
     end
   end
 end

--- a/lib/much-plugin.rb
+++ b/lib/much-plugin.rb
@@ -1,22 +1,20 @@
 require "much-plugin/version"
 
 module MuchPlugin
-
   def self.included(receiver)
     receiver.class_eval{ extend ClassMethods }
   end
 
   module ClassMethods
-
-    # install an included hook that first checks if this plugin's receiver mixin
+    # install an included block that first checks if this plugin's receiver mixin
     # has already been included.  If it has not been, include the receiver mixin
-    # and run all of the `plugin_included` hooks
+    # and run all of the `plugin_included` blocks
     def included(plugin_receiver)
       return if plugin_receiver.include?(self.much_plugin_included_detector)
       plugin_receiver.send(:include, self.much_plugin_included_detector)
 
-      self.much_plugin_included_hooks.each do |hook|
-        plugin_receiver.class_eval(&hook)
+      self.much_plugin_included_blocks.each do |block|
+        plugin_receiver.class_eval(&block)
       end
     end
 
@@ -31,12 +29,12 @@ module MuchPlugin
       end
     end
 
-    def much_plugin_included_hooks; @much_plugin_included_hooks ||= []; end
-
-    def plugin_included(&hook)
-      self.much_plugin_included_hooks << hook
+    def much_plugin_included_blocks
+      @much_plugin_included_blocks ||= []
     end
 
+    def plugin_included(&block)
+      self.much_plugin_included_blocks << block
+    end
   end
-
 end

--- a/much-plugin.gemspec
+++ b/much-plugin.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.16.3"])
+  gem.add_development_dependency("assert", ["~> 2.17.0"])
 
 end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,4 +1,4 @@
-require 'assert/factory'
+require "assert/factory"
 
 module Factory
   extend Assert::Factory

--- a/test/system/much-plugin_tests.rb
+++ b/test/system/much-plugin_tests.rb
@@ -1,0 +1,54 @@
+require "assert"
+require "much-plugin"
+
+module MuchPlugin
+  class SystemTests < Assert::Context
+    desc "MuchPlugin"
+    setup do
+      @my_class = MyClass.new
+    end
+    subject{ @my_class }
+
+    should "class eval the plugin included block on MyClass" do
+      assert_equal "another", subject.another
+    end
+
+    should "add the plugin class methods to MyClass" do
+      assert_equal "a-class-method", MyClass.a_class_method
+    end
+
+    should "add the plugin instance methods to MyClass" do
+      assert_equal "an-instance-method", subject.an_instance_method
+    end
+
+    module AnotherMixin
+      def another
+        "another"
+      end
+    end
+
+    module MyPlugin
+      include MuchPlugin
+
+      plugin_included do
+        include AnotherMixin
+      end
+
+      plugin_class_methods do
+        def a_class_method
+          "a-class-method"
+        end
+      end
+
+      plugin_instance_methods do
+        def an_instance_method
+          "an-instance-method"
+        end
+      end
+    end
+
+    class MyClass
+      include MyPlugin
+    end
+  end
+end

--- a/test/unit/much-plugin_tests.rb
+++ b/test/unit/much-plugin_tests.rb
@@ -1,19 +1,18 @@
-require 'assert'
-require 'much-plugin'
+require "assert"
+require "much-plugin"
 
 module MuchPlugin
-
   class UnitTests < Assert::Context
     desc "MuchPlugin"
     setup do
-      @hook1 = proc{ 1 }
-      @hook2 = proc{ 2 }
+      @block1 = proc{ 1 }
+      @block2 = proc{ 2 }
 
       @plugin = Module.new{ include MuchPlugin }
     end
     subject{ @plugin }
 
-    should have_imeths :much_plugin_included_detector, :much_plugin_included_hooks
+    should have_imeths :much_plugin_included_detector, :much_plugin_included_blocks
     should have_imeths :plugin_included
 
     should "know its included detector" do
@@ -24,54 +23,53 @@ module MuchPlugin
       assert_same exp, subject.much_plugin_included_detector
     end
 
-    should "have no plugin included hooks by default" do
-      assert_empty subject.much_plugin_included_hooks
+    should "have no plugin included blocks by default" do
+      assert_empty subject.much_plugin_included_blocks
     end
 
-    should "append hooks" do
-      subject.plugin_included(&@hook1)
-      subject.plugin_included(&@hook2)
+    should "append blocks" do
+      subject.plugin_included(&@block1)
+      subject.plugin_included(&@block2)
 
-      assert_equal @hook1, subject.much_plugin_included_hooks.first
-      assert_equal @hook2, subject.much_plugin_included_hooks.last
+      assert_equal @block1, subject.much_plugin_included_blocks.first
+      assert_equal @block2, subject.much_plugin_included_blocks.last
     end
-
   end
 
   class MixedInTests < UnitTests
     desc "when mixed in"
     setup do
       @receiver = Class.new do
-        def self.inc_hook1;   @hook1_count ||= 0; @hook1_count += 1; end
-        def self.hook1_count; @hook1_count ||= 0; end
-        def self.inc_hook2;   @hook2_count ||= 0; @hook2_count += 1; end
-        def self.hook2_count; @hook2_count ||= 0; end
+        def self.inc_block1;   @block1_count ||= 0; @block1_count += 1; end
+        def self.block1_count; @block1_count ||= 0; end
+        def self.inc_block2;   @block2_count ||= 0; @block2_count += 1; end
+        def self.block2_count; @block2_count ||= 0; end
       end
     end
 
-    should "call the plugin included hooks" do
-      assert_equal 0, @receiver.hook1_count
-      assert_equal 0, @receiver.hook2_count
+    should "call the plugin included blocks" do
+      assert_equal 0, @receiver.block1_count
+      assert_equal 0, @receiver.block2_count
 
       @receiver.send(:include, TestPlugin)
 
-      assert_equal 1, @receiver.hook1_count
-      assert_equal 1, @receiver.hook2_count
+      assert_equal 1, @receiver.block1_count
+      assert_equal 1, @receiver.block2_count
     end
 
-    should "call hooks only once no matter even if previously mixed in" do
+    should "call blocks only once no matter even if previously mixed in" do
       @receiver.send(:include, TestPlugin)
 
-      assert_equal 1, @receiver.hook1_count
-      assert_equal 1, @receiver.hook2_count
+      assert_equal 1, @receiver.block1_count
+      assert_equal 1, @receiver.block2_count
 
       @receiver.send(:include, TestPlugin)
 
-      assert_equal 1, @receiver.hook1_count
-      assert_equal 1, @receiver.hook2_count
+      assert_equal 1, @receiver.block1_count
+      assert_equal 1, @receiver.block2_count
     end
 
-    should "call hooks only once even if mixed in by a 3rd party" do
+    should "call blocks only once even if mixed in by a 3rd party" do
       third_party = Module.new do
         def self.included(receiver)
           receiver.send(:include, TestPlugin)
@@ -79,27 +77,25 @@ module MuchPlugin
       end
       @receiver.send(:include, third_party)
 
-      assert_equal 1, @receiver.hook1_count
-      assert_equal 1, @receiver.hook2_count
+      assert_equal 1, @receiver.block1_count
+      assert_equal 1, @receiver.block2_count
 
       @receiver.send(:include, TestPlugin)
 
-      assert_equal 1, @receiver.hook1_count
-      assert_equal 1, @receiver.hook2_count
+      assert_equal 1, @receiver.block1_count
+      assert_equal 1, @receiver.block2_count
 
       @receiver.send(:include, third_party)
 
-      assert_equal 1, @receiver.hook1_count
-      assert_equal 1, @receiver.hook2_count
+      assert_equal 1, @receiver.block1_count
+      assert_equal 1, @receiver.block2_count
     end
 
     TestPlugin = Module.new do
       include MuchPlugin
 
-      plugin_included{ inc_hook1 }
-      plugin_included{ inc_hook2 }
+      plugin_included{ inc_block1 }
+      plugin_included{ inc_block2 }
     end
-
   end
-
 end


### PR DESCRIPTION
This adds `plugin_{instance|class}_methods` helper methods for
defining instance and class methods on plugin receivers. This is
not only a more convenient way of defining these types of methods,
it also more closely matches ActiveSupport's Concern API so it
may be more intuitive for developers who are used to that API.

## Other Changes

### apply our latest conventions and do some cleanups

It has been over a year since I have looked at this gem and in that
time we have modified our coding conventions a bit. This updates
the repo accordingly including:

* Switched to always using double-quotes for defining strings.
  Using single vs double quotes doesn't really affect anything like
  it could have in the early days of Ruby.
* Removed empty lines around class/module definitions.

This also cleans up the following:

* Update to the latest version of Assert. This is just to keep up
  with the latest stuff.
* Rename the use of "hook" in the code to "block". I can't remember
  why I originally chose to name the blocks "hooks" and "block" is
  a way more intuitive name.
