### PR TITLE
add `after_plugin_included` directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,28 @@ module MyPluginMixin
 end
 ```
 
+### `after_plugin_included`
+
+These hooks work just like the `plugin_included` hooks, except they are evaluated _after_ any plugin class/instance methods have been evaluated. E.g. use this to call a class method that the plugin defines.
+
+```ruby
+requre "much-plugin"
+
+module MyPluginMixin
+  include MuchPlugin
+
+  after_plugin_included do
+    configure_the_plugin
+  end
+
+  plugin_class_methods do
+    def configure_the_plugin
+      # ...
+    end
+  end
+end
+```
+
 ## Example
 
 ```ruby

--- a/lib/much-plugin.rb
+++ b/lib/much-plugin.rb
@@ -26,6 +26,10 @@ module MuchPlugin
         self.much_plugin_instance_methods_module.class_eval(&block)
       end
       plugin_receiver.send(:include, self.much_plugin_instance_methods_module)
+
+      self.much_plugin_after_included_blocks.each do |block|
+        plugin_receiver.class_eval(&block)
+      end
     end
 
     # the included detector is an empty module that is only used to detect if
@@ -55,6 +59,10 @@ module MuchPlugin
       @much_plugin_included_blocks ||= []
     end
 
+    def much_plugin_after_included_blocks
+      @much_plugin_after_included_blocks ||= []
+    end
+
     def much_plugin_class_method_blocks
       @much_plugin_class_method_blocks ||= []
     end
@@ -65,6 +73,10 @@ module MuchPlugin
 
     def plugin_included(&block)
       self.much_plugin_included_blocks << block
+    end
+
+    def after_plugin_included(&block)
+      self.much_plugin_after_included_blocks << block
     end
 
     def plugin_class_methods(&block)


### PR DESCRIPTION
`plugin_included` blocks are evaluated before any methods in
`plugin_class_methods` are evaluated. This meant you couldn't call
a plugin's class methods in its `plugin_included` block b/c that
class method didn't exist (yet).

This adds a new directive: `after_plugin_included` that allows you
to evaluate logic _after_ any `plugin_class_methods` and
`plugin_instance_methods` have been evaluated.